### PR TITLE
Fix the error `Warning: date_timezone_set() expects parameter 1 to be DateTime`

### DIFF
--- a/config/demo.settings.json
+++ b/config/demo.settings.json
@@ -1,7 +1,7 @@
 {
     "_config_name": "demo.settings",
     "demo_dump_path": "demo",
-    "demo_reset_last": "novalue",
-    "demo_reset_interval": "novalue",
+    "demo_reset_last": "",
+    "demo_reset_interval": "",
     "demo_dump_cron": "demo_site"
 }

--- a/demo.admin.inc
+++ b/demo.admin.inc
@@ -62,7 +62,7 @@ function demo_manage_form($form, &$form_state) {
   $form['status']['reset_last'] = array(
     '#type' => 'item',
     '#title' => t('Last reset'),
-    '#markup' => $reset_date ? format_date($reset_date) : t('Never'),
+    '#markup' => is_numeric($reset_date) ? format_date($reset_date) : t('Never'),
   );
 
   $form['dump'] = demo_get_dumps();

--- a/demo.admin.inc
+++ b/demo.admin.inc
@@ -62,7 +62,7 @@ function demo_manage_form($form, &$form_state) {
   $form['status']['reset_last'] = array(
     '#type' => 'item',
     '#title' => t('Last reset'),
-    '#markup' => is_numeric($reset_date) ? format_date($reset_date) : t('Never'),
+    '#markup' => $reset_date ? format_date($reset_date) : t('Never'),
   );
 
   $form['dump'] = demo_get_dumps();

--- a/demo.install
+++ b/demo.install
@@ -28,8 +28,8 @@ function demo_update_last_removed() {
 function demo_update_1000() {
   $config = config('demo.settings');
   $config->set('demo_dump_path', update_variable_get('demo_dump_path', 'demo'));
-  $config->set('demo_reset_last', update_variable_get('demo_reset_last', 'novalue'));
-  $config->set('demo_reset_interval', update_variable_get('demo_reset_interval', 'novalue'));
+  $config->set('demo_reset_last', update_variable_get('demo_reset_last', ''));
+  $config->set('demo_reset_interval', update_variable_get('demo_reset_interval', ''));
   $config->set('demo_dump_cron', update_variable_get('demo_dump_cron', 'demo_site'));
   update_variable_del('demo_dump_path');
   update_variable_del('demo_reset_last');


### PR DESCRIPTION
Fixes the `Warning: date_timezone_set() expects parameter 1 to be DateTime` error per https://github.com/backdrop-contrib/demo/issues/1#issuecomment-541447705