### PR TITLE
Warning: date_timezone_set() expects parameter 1 to be DateTime

### DIFF
--- a/config/demo.settings.json
+++ b/config/demo.settings.json
@@ -1,7 +1,7 @@
 {
     "_config_name": "demo.settings",
     "demo_dump_path": "demo",
-    "demo_reset_last": "novalue",
-    "demo_reset_interval": "novalue",
+    "demo_reset_last": "",
+    "demo_reset_interval": "",
     "demo_dump_cron": "demo_site"
 }

--- a/demo.install
+++ b/demo.install
@@ -28,8 +28,8 @@ function demo_update_last_removed() {
 function demo_update_1000() {
   $config = config('demo.settings');
   $config->set('demo_dump_path', update_variable_get('demo_dump_path', 'demo'));
-  $config->set('demo_reset_last', update_variable_get('demo_reset_last', 'novalue'));
-  $config->set('demo_reset_interval', update_variable_get('demo_reset_interval', 'novalue'));
+  $config->set('demo_reset_last', update_variable_get('demo_reset_last', ''));
+  $config->set('demo_reset_interval', update_variable_get('demo_reset_interval', ''));
   $config->set('demo_dump_cron', update_variable_get('demo_dump_cron', 'demo_site'));
   update_variable_del('demo_dump_path');
   update_variable_del('demo_reset_last');


### PR DESCRIPTION
Presetting the `demo_reset_last` and `demo_reset_interval` configuration variables to `novalue` string causes the error described on https://github.com/backdrop-contrib/demo/issues/1. On the contrary setting empty values for both variables causes no error.